### PR TITLE
Add support for name in From header

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -35,6 +35,17 @@ function SipMessage(msg) {
     }
   }) ;
 
+  Object.defineProperty(this, 'callingName', {
+    get: function() {
+      const header = this.has('p-asserted-identity') ? this.get('p-asserted-identity') : this.get('from') ;
+      const user  = header.match(/^\"(.+)\" <sip:.+@/);
+      if (user && user.length > 1) {
+        return user[1];
+      }
+      return '';
+    }
+  });
+
   Object.defineProperty(this, 'canFormDialog', {
     get: function() {
       return ('INVITE' === this.method || 'SUBSCRIBE' === this.method) && !this.get('to').tag ;

--- a/test/parser.js
+++ b/test/parser.js
@@ -85,6 +85,12 @@ describe('Parser', function(){
     var msg = new SipMessage(examples('invite')) ;
     msg.callingNumber.should.eql('4083084809') ;
   }) ;
+  it('should parse calling name', function(){
+    var msg = new SipMessage() ;
+    msg.set('From', '"Dave" <sip:daveh@localhost>;tag=1234') ;
+    msg.get('From').should.eql('"Dave" <sip:daveh@localhost>;tag=1234') ;
+    msg.callingName.should.eql('Dave');
+  }) ;
   it('should parse ipv4 dot decimal sip uri', function(){
     var uri = parseUri('sip:104461@10.1.0.100:61219;rinstance=39ccb7d8db4387b1;transport=tcp') ;
     uri.family.should.eql('ipv4');


### PR DESCRIPTION
Hi @davehorton.

When using drachtio-srf to create a B2BUA and passing the header from with the contact name, the header was not passed to the server-side.

This is just the support for the parser for now I will open a PR in drachtio-srf with the changes to the B2BUA.

Best regards.