### PR TITLE
fix for issue OPTIONS parsing issue

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -194,7 +194,7 @@ function parse(data, lazy) {
   for (let i = 1; i < data.length; ++i) {
     const r = data[i].match(/^([\S]*?)\s*:\s*([\s\S]*)$/);
     if (!r) {
-      return;
+      continue;
     }
 
     const name = getHeaderName(r[1]) ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "drachtio-sip",
       "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
@@ -17,7 +18,7 @@
         "eslint-plugin-promise": "^4.2.1",
         "mocha": "^9.0.2",
         "should": "^13.2.3",
-        "sip-message-examples": "0.0.6"
+        "sip-message-examples": "0.0.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1662,11 +1663,10 @@
       "dev": true
     },
     "node_modules/sip-message-examples": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/sip-message-examples/-/sip-message-examples-0.0.6.tgz",
-      "integrity": "sha512-pw61eDZIZP+nPanEHqJ0URYxlSB2jYpvXv779LNfx5clrCe9p6Yhhf1+kvK9o0n41v98x3FqqW8OX6NtDntZMg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/sip-message-examples/-/sip-message-examples-0.0.7.tgz",
+      "integrity": "sha512-OESNjIPM1QbewqKMEFDmy6jOvrtjUgUnZPSBg5rGjPKBwxTbewGuf+9EMwv+iM5wUJZvO9EQHTz/fl3yZKzCtQ==",
+      "dev": true
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
@@ -3349,9 +3349,9 @@
       "dev": true
     },
     "sip-message-examples": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/sip-message-examples/-/sip-message-examples-0.0.6.tgz",
-      "integrity": "sha512-pw61eDZIZP+nPanEHqJ0URYxlSB2jYpvXv779LNfx5clrCe9p6Yhhf1+kvK9o0n41v98x3FqqW8OX6NtDntZMg==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/sip-message-examples/-/sip-message-examples-0.0.7.tgz",
+      "integrity": "sha512-OESNjIPM1QbewqKMEFDmy6jOvrtjUgUnZPSBg5rGjPKBwxTbewGuf+9EMwv+iM5wUJZvO9EQHTz/fl3yZKzCtQ==",
       "dev": true
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "mocha": "^9.0.2",
     "should": "^13.2.3",
-    "sip-message-examples": "0.0.6"
+    "sip-message-examples": "0.0.7"
   },
   "scripts": {
     "test": "make test",

--- a/test/parser.js
+++ b/test/parser.js
@@ -6,6 +6,18 @@ var parser = require('..').parser ;
 var parseUri = require('..').parser.parseUri ;
 var debug = require('debug')('drachtio-sip') ;
 
+var optionsMsg =  'OPTIONS sip:mgAUQnkm@3.208.209.143 SIP/2.0\r\n' +
+'Via: SIP/2.0/UDP 192.241.212.6:56500;branch=nGTWdf.1124599842;rport;alias\r\n' +
+'From: sip:OYlmFAQc@192.241.212.6:56500;tag=71186921\r\n' +
+'To: sip:RTGYLGsX@3.208.209.143\r\n' +
+'Call-ID: 3652223354@192.241.212.6\r\n' +
+'CSeq: 1 OPTIONS\r\n' +
+'Contact: sip:IDwgWVsn@192.241.212.6:56500\r\n' +
+'Content-Length: 0\r\n' +
+'Max-Forwards: 20\r\n' +
+'User-Agent: wFkdhplQ\r\n' +
+'Accept: text/plain\r\n';
+
 describe('Parser', function(){
   it('should provide headers as string values', function(){
     var msg = new SipMessage(examples('invite')) ;
@@ -14,7 +26,7 @@ describe('Parser', function(){
   it('should optionally provide a parsed header', function(){
     var msg = new SipMessage(examples('invite')) ;
     var obj = msg.getParsedHeader('from') ;
-    obj.should.be.type('object'); 
+    obj.should.be.type('object');
     obj.should.have.property('uri') ;
   }) ;
 
@@ -102,24 +114,24 @@ describe('Parser', function(){
     uri.family.should.eql('ipv6');
     uri.host.should.eql('[2601:182:cd00:d4c6:604b:16f1:3f5a:44f8]') ;
     uri.port.should.eql(61219);
-  }) ;  
+  }) ;
   it('should parse a sip uri with a dash or underscore', function(){
     var uri = parseUri('sip:116751x0@cor10-san.sip.phone.com') ;
     uri.family.should.eql('ipv4');
     uri.host.should.eql('cor10-san.sip.phone.com') ;
     uri.user.should.eql('116751x0');
-  }) ;  
+  }) ;
   it('should parse a sips uri', function(){
     var uri = parseUri('sips:116751x0@cor10-san.sip.phone.com') ;
     uri.family.should.eql('ipv4');
     uri.host.should.eql('cor10-san.sip.phone.com') ;
     uri.user.should.eql('116751x0');
     uri.scheme.should.eql('sips');
-  }) ;  
+  }) ;
   it('should parse a multi-part header', function(){
     var msg = new SipMessage(examples('siprec')) ;
     msg.payload.length.should.eql(2);
-  }) ;  
+  }) ;
   it('should parse a multi-part header with whitespace before boundary', function(){
     var msg = new SipMessage(examples('siprec2')) ;
     msg.payload.length.should.eql(2);
@@ -138,6 +150,10 @@ describe('Parser', function(){
     msg.set('From', '"Dave" <sip:daveh@localhost>;tag=1234') ;
     msg.get('From').should.eql('"Dave" <sip:daveh@localhost>;tag=1234') ;
     msg.callingName.should.eql('Dave');
+  }) ;
+  it('should parse request with carriage return on last line', function(){
+    var msg = new SipMessage(optionsMsg) ;
+    (typeof msg.get('from')).should.eql('string') ;
   }) ;
 }) ;
 

--- a/test/parser.js
+++ b/test/parser.js
@@ -6,18 +6,6 @@ var parser = require('..').parser ;
 var parseUri = require('..').parser.parseUri ;
 var debug = require('debug')('drachtio-sip') ;
 
-var optionsMsg =  'OPTIONS sip:mgAUQnkm@3.208.209.143 SIP/2.0\r\n' +
-'Via: SIP/2.0/UDP 192.241.212.6:56500;branch=nGTWdf.1124599842;rport;alias\r\n' +
-'From: sip:OYlmFAQc@192.241.212.6:56500;tag=71186921\r\n' +
-'To: sip:RTGYLGsX@3.208.209.143\r\n' +
-'Call-ID: 3652223354@192.241.212.6\r\n' +
-'CSeq: 1 OPTIONS\r\n' +
-'Contact: sip:IDwgWVsn@192.241.212.6:56500\r\n' +
-'Content-Length: 0\r\n' +
-'Max-Forwards: 20\r\n' +
-'User-Agent: wFkdhplQ\r\n' +
-'Accept: text/plain\r\n';
-
 describe('Parser', function(){
   it('should provide headers as string values', function(){
     var msg = new SipMessage(examples('invite')) ;
@@ -152,7 +140,7 @@ describe('Parser', function(){
     msg.callingName.should.eql('Dave');
   }) ;
   it('should parse request with carriage return on last line', function(){
-    var msg = new SipMessage(optionsMsg) ;
+    var msg = new SipMessage(examples('options-carriage-return')) ;
     (typeof msg.get('from')).should.eql('string') ;
   }) ;
 }) ;


### PR DESCRIPTION
I think this should fix the issue reported in [112](https://github.com/drachtio/drachtio-srf/issues/122). The issue with the OPTIONS request is that there is a carriage return on the last line, which makes [the loop here](https://github.com/drachtio/drachtio-sip/blob/e573d9fc2fa31e06b2c9ab320a8907ff072b8bd1/lib/parser.js#L194) go one more time with empty data, which causes `r` to be undefined and the whole function [returns undefined](https://github.com/drachtio/drachtio-sip/blob/e573d9fc2fa31e06b2c9ab320a8907ff072b8bd1/lib/parser.js#L197).

You'll notice I added the OPTIONS header as a plain variable in the test, but we will need to do is add the extra carriage return OPTIONS to the [sip-message-examples](https://github.com/davehorton/sip-message-examples) repo to get the test passing correctly for the current setup. I already made a pull request for that [https://github.com/davehorton/sip-message-examples/pull/3](https://github.com/davehorton/sip-message-examples/pull/3). Once that is merged, I can update the test so it uses the message from [sip-message-examples](https://github.com/davehorton/sip-message-examples).